### PR TITLE
implement send mail

### DIFF
--- a/examples/checks_config.yaml
+++ b/examples/checks_config.yaml
@@ -31,7 +31,13 @@ checks:
     function: squeue
 monitoring:
   status_file: "./status.yaml"
-  mail_to: []
+  mail_to: ["example@example.com", ]
   intervals_hours:
     not_triggering: 72
     when_triggering: 4
+  mail_settings:
+    smtp_server: ""
+    port: 0
+    sender: ""
+    password: ""
+    instance_name: ""

--- a/examples/checks_config_mockchecks.yaml
+++ b/examples/checks_config_mockchecks.yaml
@@ -15,7 +15,13 @@ checks:
       always_fail: true
 monitoring:
   status_file: "./status.yaml"
-  mail_to: []
+  mail_to: ["example@example.com", ]
   intervals_hours:
     not_triggering: 72
     when_triggering: 4
+  mail_settings:
+    smtp_server: ""
+    port: 0
+    sender: ""
+    password: ""
+    instance_name: ""


### PR DESCRIPTION
This implements the "send emails with reports" functionality using `smtplib`.

While the "should we send another email?" logic is unchanged, now a `reason` string is returned by `call_checks`, to be used in the mail subject.
It describes why that email was sent, with three possible states: no prior emails; at least one check is triggering or failing; all ok, but enough time (`monitoring.intervals_hours.not_triggering`) has passed.